### PR TITLE
Parser: Only trim spec-allowed whitespace

### DIFF
--- a/fluent-base/src/main/java/fluent/syntax/parser/FTLPatternParser.java
+++ b/fluent-base/src/main/java/fluent/syntax/parser/FTLPatternParser.java
@@ -174,7 +174,16 @@ class FTLPatternParser {
                     String text = ps.subString( start, textElement.end() );
 
                     if (lastNonBlank == count) {
-                        text = text.stripTrailing();
+                        int length = text.length();
+                        int endIndex = length;
+                        while (0 < endIndex) {
+                            int codepoint = text.codePointBefore(endIndex);
+                            if (codepoint != ' ' && codepoint != '\t' && codepoint != '\r' && codepoint != '\n') {
+                                break;
+                            }
+                            endIndex -= Character.charCount(codepoint);
+                        }
+                        text = text.substring(0, endIndex);
                     }
 
                     patternElements.add( new PatternElement.TextElement( text ) );

--- a/fluent-base/src/test/java/FTLParserSmokeTest.java
+++ b/fluent-base/src/test/java/FTLParserSmokeTest.java
@@ -130,6 +130,29 @@ class FTLParserSmokeTest {
     }
 
     @Test
+    void blankUnicodeTest() {
+        // These tests use string concatenation because triple-quotes strip trailing whitespace
+        String thinSpace = String.valueOf(Character.toChars(0x2009));
+
+        assertEquals(
+                thinSpace,
+                msg( "quote =" + thinSpace, "quote" )
+        );
+
+        assertEquals(
+                thinSpace,
+                msg( "-t =" + thinSpace + "\nquote = { -t }", "quote" )
+        );
+
+        String s1 = "example = { NUMBER($cnt) ->\n    [one] hello\n    *[other]" + thinSpace + "\n}";
+
+        assertEquals(
+                thinSpace,
+                msg( s1, "example", Map.of("cnt", 0) )
+        );
+    }
+
+    @Test
     void literalTest() {
         String s1 = """
                 literal-string = {"abc123"}


### PR DESCRIPTION
Unlike Java's definition of whitespace (which includes all of Unicode's space characters plus some separators), Fluent's definition is limited to the literal space character, 0x0020. (See [ref].)

I changed the behavior of `getPattern` to select all allowed whitespace, treating (for example) 0x2009 as a valid pattern.

Closes #4.

[ref]: https://github.com/projectfluent/fluent/blob/fd8f95478e29dda8121da7e275d375eb8dadbcb0/spec/fluent.ebnf#L135